### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           account_key: ${{ secrets.GCLOUD_KEY }}
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: lorenzorivosecchi/superorch_api
           registry: eu.gcr.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore